### PR TITLE
fix!: delete steam-overlay

### DIFF
--- a/repos.conf/eselect-repo.conf
+++ b/repos.conf/eselect-repo.conf
@@ -15,9 +15,3 @@ location = /var/db/repos/ncaq-overlay
 sync-type = git
 sync-uri = https://github.com/ncaq/ncaq-overlay.git
 sync-depth = 0
-
-[steam-overlay]
-location = /var/db/repos/steam-overlay
-sync-type = git
-sync-uri = https://github.com/gentoo-mirror/steam-overlay.git
-


### PR DESCRIPTION
しばらくはゲームする時は諦めてWindowsを使うことにします。
新しくラップトップPCを買ってsteam-overlayが入った状態でインストールされたPCがなくなるので、 良い機会だと思いました。