### PR TITLE
feat: device-mapperを有効化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-package.use/device-*
+package.use/install-*
 
 savedconfig/
 

--- a/install
+++ b/install
@@ -17,7 +17,7 @@ MAKEOPTS='-j$(nproc)'" >> "$portage_dir"/make.conf
 
 # AVXなどの使えるCPUの使える機能を読み出すにはコマンド呼び出しが必要。
 install-cpu-flags() {
-  echo "*/* $(cpuid2cpuflags)" > "$portage_dir"/package.use/device-cpu-flags
+  echo "*/* $(cpuid2cpuflags)" > "$portage_dir"/package.use/install-cpu-flags
 }
 
 # デバイスによって搭載されているビデオカードが異なる。
@@ -38,14 +38,14 @@ install-video() {
   esac
   case $video_card in
     nvidia)
-      echo '*/* VIDEO_CARDS: -* nvidia' > "$portage_dir"/package.use/device-video-cards
-      echo '*/* vdpau nvdec nvenc' > "$portage_dir"/package.use/device-video-acceleration
+      echo '*/* VIDEO_CARDS: -* nvidia' > "$portage_dir"/package.use/install-video-cards
+      echo '*/* vdpau nvdec nvenc' > "$portage_dir"/package.use/install-video-acceleration
       ;;
     amd)
-      echo '*/* VIDEO_CARDS: -* amdgpu radeonsi' > "$portage_dir"/package.use/device-video-cards
+      echo '*/* VIDEO_CARDS: -* amdgpu radeonsi' > "$portage_dir"/package.use/install-video-cards
       # amfは現状プロプライエタリなドライバが必要らしいのと、
       # 現状AMD GPUで動画をエンコードする需要が個人的に無いので有効化していない。
-      echo '*/* vaapi vdpau' > "$portage_dir"/package.use/device-video-acceleration
+      echo '*/* vaapi vdpau' > "$portage_dir"/package.use/install-video-acceleration
       ;;
     *)
       echo "Unknown video card: $video_card" >&2

--- a/package.use/device-mapper
+++ b/package.use/device-mapper
@@ -1,0 +1,3 @@
+*/* device-mapper
+
+app-containers/docker -device-mapper


### PR DESCRIPTION
暗号化ドライブの利用におそらく必要でした。
これまでデバイス依存としてignoreしてきたdeviceプレフィクス名と衝突することが分かったため、 installされるものはinstallプレフィクス名を使用するように変更した。