### PR TITLE
fix: libreofficeのstableが正常にビルドできるように修正

### DIFF
--- a/package.accept_keywords/00-libreoffice
+++ b/package.accept_keywords/00-libreoffice
@@ -1,1 +1,4 @@
 app-office/libreoffice* -~amd64
+
+dev-cpp/libcmis -~amd64
+dev-libs/icu -~amd64


### PR DESCRIPTION
バグ報告をしてもunstableと混ぜるのが悪いと受け取ってもらえなかったため。