### PR TITLE
feat: bump dlang to 2.104

### DIFF
--- a/install.d/package.use/base/dlang
+++ b/install.d/package.use/base/dlang
@@ -1,3 +1,3 @@
-*/* dmd-2_099
+*/* dmd-2_104
 
-dev-lang/dmd -dmd-2_099 selfhost tools
+dev-lang/dmd -dmd-2_104 selfhost tools


### PR DESCRIPTION
古いdmdなどがportageから消えたのでアップデート。
一応AtCoderに合わせています。