### PR TITLE
feat: global USE flag of grub and dracut

### DIFF
--- a/install.d/package.use/base/grub
+++ b/install.d/package.use/base/grub
@@ -1,4 +1,4 @@
-*/* GRUB_PLATFORMS: -* efi-64
+*/* grub dracut GRUB_PLATFORMS: -* efi-64
 
 # required by sys-boot/os-prober-1.81::gentoo
 >=sys-boot/grub-2.06-r3 mount


### PR DESCRIPTION
sys-kernel/installkernelによる自動化のために必要。
特に強い害はないので雑にグローバルに有効化する。