### PR TITLE
fix: `virtual/dist-kernel`のunstableを不許可

### DIFF
--- a/package.accept_keywords/00-sys
+++ b/package.accept_keywords/00-sys
@@ -1,2 +1,3 @@
 sys-boot/* -~amd64
 sys-kernel/* -~amd64
+virtual/dist-kernel -~amd64


### PR DESCRIPTION
gentoo-kernelなどをstableにしているため帳尻を合わせたいため。