### PR TITLE
fix: waylandを有効にしないでビルドする

### DIFF
--- a/install.d/package.use/client/chromium
+++ b/install.d/package.use/client/chromium
@@ -1,4 +1,7 @@
+www-client/chromium -screencast -wayland
+
 # required by www-client/chromium-106.0.5249.119::gentoo
 >=dev-lang/rust-1.75.0 profiler
 >=net-libs/nodejs-18.11.0 inspector
+>=virtual/rust-1.77.1 profiler
 sys-libs/zlib minizip


### PR DESCRIPTION
chromiumがデフォルト有効にするようになったが、
xmonadを使いたいので代替が成熟するか、
メインで使っているFirefoxがWayland限定機能とか作り始めるまでX11に留まる。