### PR TITLE
fix: dlangの新しいUSEフラグ形式に対応

### DIFF
--- a/install.d/package.use/base/dlang
+++ b/install.d/package.use/base/dlang
@@ -1,3 +1,4 @@
-*/* dmd-2_104
+*/* DLANG_SINGLE_TARGET: ldc2-1_36
 
-dev-lang/dmd -dmd-2_104 selfhost tools
+dev-lang/dmd selfhost DLANG_SINGLE_TARGET: -ldc2-1_36
+dev-lang/ldc2 dmd-2_106 DLANG_SINGLE_TARGET: -ldc2-1_36 dmd-2_106

--- a/package.accept_keywords/00-dlang
+++ b/package.accept_keywords/00-dlang
@@ -1,2 +1,0 @@
-dev-lang/dmd -~amd64
-dev-util/dlang-tools -~amd64


### PR DESCRIPTION
* `DLANG_SINGLE_TARGET`を基本とする
* 古い形式のUSEフラグにも対応する
* ldc2の安定版を基本とする
* ldc2はバージョンごとに循環参照を解決するのが面倒なのでselfhostを提供しているdmdに依存することにする
  * ldc2自体のパフォーマンスはしょせんコンパイラなのでそこまで気にしなくても良いはず