### PR TITLE
fix: dlang to stable

### DIFF
--- a/install.d/package.use/base/dlang
+++ b/install.d/package.use/base/dlang
@@ -1,4 +1,4 @@
-*/* DLANG_SINGLE_TARGET: ldc2-1_36
+*/* DLANG_SINGLE_TARGET: ldc2-1_35
 
-dev-lang/dmd selfhost DLANG_SINGLE_TARGET: -ldc2-1_36
-dev-lang/ldc2 dmd-2_106 DLANG_SINGLE_TARGET: -ldc2-1_36 dmd-2_106
+dev-lang/dmd selfhost DLANG_SINGLE_TARGET: -ldc2-1_35
+dev-lang/ldc2 dmd-2_106 DLANG_SINGLE_TARGET: -ldc2-1_35 dmd-2_106

--- a/package.accept_keywords/00-dlang
+++ b/package.accept_keywords/00-dlang
@@ -1,0 +1,2 @@
+dev-lang/dmd -~amd64
+dev-lang/ldc2 -~amd64


### PR DESCRIPTION
D言語関係のパッケージのバージョンが中途半端なことになっていたので、
安定版のものを使うように修正。