### PR TITLE
build: fix: .gitignoreでトップレベル以外のpackage.use/を無視するようになっていたのを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-make.profile
-package.use/
-savedconfig/
-
-make.conf
+/make.conf
+/make.profile
+/package.use/
+/savedconfig/


### PR DESCRIPTION
install.d/以下のpackage.use/も無視するようになっていたがignoreする前に生成していたので気が付かなかった。