### PR TITLE
feat: ccacheを活かしてビルド時間を短縮

### DIFF
--- a/package.accept_keywords/00-sys-compiler
+++ b/package.accept_keywords/00-sys-compiler
@@ -1,0 +1,6 @@
+sys-devel/clang* -~amd64
+sys-devel/gcc -~amd64
+sys-devel/lld* -~amd64
+sys-devel/llvm* -~amd64
+sys-libs/compiler-rt* -~amd64
+sys-libs/libomp -~amd64


### PR DESCRIPTION
デスクトップはともかくラップトップではビルド時間がかなり面倒に感じてきたため。
gccとclangはアップデートされるとccacheのキャッシュが使えなくなるためビルドにかなり時間がかかるようになるので、 安定版を使ってキャッシュが切れるタイミングを少なくする。
元々コンパイラには安定性が求められるという事情もある。
また最近はC++を趣味で書くことが減ったため不安定版の最新版まで必要ではなくなった。
Gentooならばportageの安定版でも十分新しめであるし。