### PR TITLE
feat: ビルドに必要なrustフラグを追加

### DIFF
--- a/install.d/package.use/base/bat
+++ b/install.d/package.use/base/bat
@@ -1,4 +1,0 @@
-# required by sys-apps/bat-extras-2022.07.27::guru
->=dev-lang/rust-1.67.0 rustfmt
->=dev-lang/rust-bin-1.67.0 rustfmt
->=virtual/rust-1.67.0 rustfmt

--- a/install.d/package.use/base/rust
+++ b/install.d/package.use/base/rust
@@ -1,0 +1,3 @@
+>=dev-lang/rust-1.67.0 profiler rustfmt
+>=dev-lang/rust-bin-1.67.0 profiler rustfmt
+>=virtual/rust-1.67.0 profiler rustfmt


### PR DESCRIPTION
現在profilerを必要としているのはfd。
とりあえずあっても害はなさそうなので雑に追加。