### PR TITLE
fix: `L10N`に`en-US`を追加

### DIFF
--- a/install.d/make.conf.base
+++ b/install.d/make.conf.base
@@ -1,6 +1,6 @@
 # locale
 
-L10N='ja en'
+L10N='ja en en-US'
 LINGUAS='${L10N}'
 PLOCALES='${L10N}'
 


### PR DESCRIPTION
`app-dicts/myspell-en`が何らかの英語バリアントを要求するようになった。
特段何かを求めているわけではないのでビルドを通すためだけにアメリカ英語の設定をする。
en自体を消してしまうのはlocaleでjaがサポートされてない場合にせめて英語を使えるようにしたいためやめておく。