### PR TITLE
feat: rustコンパイラをstableに変更

### DIFF
--- a/package.accept_keywords/00-rust
+++ b/package.accept_keywords/00-rust
@@ -1,0 +1,3 @@
+dev-lang/rust -~amd64
+dev-lang/rust-bin -~amd64
+virtual/rust -~amd64


### PR DESCRIPTION
LLVMがstableなのでunstableなLLVMに依存するrustもstableしか使えないことがあるので、 無駄にアップデートがブロックされていると表示されないようにする。