### PR TITLE
feat: Node.jsをstable版を使うようにする

### DIFF
--- a/package.accept_keywords/00-nodejs
+++ b/package.accept_keywords/00-nodejs
@@ -1,0 +1,1 @@
+net-libs/nodejs -~amd64


### PR DESCRIPTION
ビルドにかなりの時間がかかるため。
安定版でもGentooなら十分最新なので問題ない。