### PR TITLE
fix: copyqのqt6対応を無効化する

### DIFF
--- a/install.d/package.use/client/copyq
+++ b/install.d/package.use/client/copyq
@@ -1,0 +1,1 @@
+x11-misc/copyq -qt6


### PR DESCRIPTION
`qtwayland`のバージョン6を要求し、
それがGTKやQtなどのWaylandサポートを大きく要求するため。
まだXMonadに頼りきりでそこまでWayland限定のメリットも感じないため。