### PR TITLE
feat!: drop ruby 3.1

### DIFF
--- a/install.d/package.use/base/ruby
+++ b/install.d/package.use/base/ruby
@@ -1,1 +1,1 @@
-*/* RUBY_TARGETS: ruby31 ruby32 ruby33
+*/* RUBY_TARGETS: ruby32 ruby33


### PR DESCRIPTION
Ruby 3.2がportageの安定版として提供されているので、
Ruby 3.1を削除します。
