### PR TITLE
fix: copyqに必要なwaylandフラグだけを有効化

### DIFF
--- a/install.d/package.use/client/copyq
+++ b/install.d/package.use/client/copyq
@@ -1,1 +1,4 @@
-x11-misc/copyq -qt6
+# required by x11-misc/copyq-9.1.0::gentoo
+>=dev-qt/qtbase-6.7.3-r2 wayland
+>=media-libs/mesa-24.2.7 wayland
+>=x11-libs/gtk+-3.24.42-r1 wayland


### PR DESCRIPTION
WaylandはXMonadにべったりの今必要ないが、
copyqがビルド時に依存しているためでインストールするためには必要。
X11でもWaylandにビルド依存しているのは作者は修正する気はないらしい。
[Wayland dependencies on Xorg-only · Issue #2830 · hluk/CopyQ](https://github.com/hluk/CopyQ/issues/2830)
