### PR TITLE
feat: python to stable

### DIFF
--- a/package.accept_keywords/00-python
+++ b/package.accept_keywords/00-python
@@ -1,0 +1,1 @@
+dev-lang/python -~amd64


### PR DESCRIPTION
[1935621 - mach fails with Python 3.12.8, Python 3.13.1 (regression with new Python releases)](https://bugzilla.mozilla.org/show_bug.cgi?id=1935621)
